### PR TITLE
Address potential issue with frontend profile editing

### DIFF
--- a/inc/class.rda-remove-access.php
+++ b/inc/class.rda-remove-access.php
@@ -113,7 +113,7 @@ class RDA_Remove_Access {
 		/** @global string $pagenow */
 		global $pagenow;
 
-		if ( 'profile.php' != $pagenow || ! $this->settings['enable_profile'] ) {
+		if ( ( $pagenow && 'profile.php' !== $pagenow ) || ( defined( 'IS_PROFILE_PAGE' ) && ! IS_PROFILE_PAGE ) || ! $this->settings['enable_profile'] ) {
 			wp_redirect( $this->settings['redirect_url'] );
 			exit;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,9 @@ example.com/options-general.php?page=dashboard-access&rda_debug=1
 
 == Changelog ==
 
+= 1.1.4 on April 18, 2022 =
+
+* Resolved: Issue when front-end editing of profiles when the `$pagenow` global is not defined ([#24](https://github.com/trustedlogin/Remove-Dashboard-Access/issues/24))
 = 1.1.3 =
 
 * Fixed a compatibility issue with bbPress and the media grid view.


### PR DESCRIPTION
Check whether global `$pagenow` has a value before relying on it. Since the hook is called using `admin_init`, I'm not sure exactly how the user has reached this code, but it's possible it could be called manually or via AJAX.

It's not a problem to check for it and to use the alternative code suggested by @shivchawla

Resolves #24 