### PR TITLE
ci: hotfix the deploy + add git-tag + GitHub-Release automation

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -85,8 +85,30 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Detected plugin version: $VERSION"
 
+      # Idempotency guard. The 10up action FAILS if the SVN tag for the
+      # current Stable tag already exists — which would happen on any
+      # re-run of the same release (manual workflow_dispatch, a
+      # follow-up commit to main that doesn't bump the version, etc.).
+      # Pre-check whether the SVN tag is already there and short-circuit
+      # the deploy step if so. The tag + release steps still run; they
+      # have their own existence guards.
+      - name: Check whether SVN already has this version tagged
+        id: svn_tag_check
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SLUG: remove-dashboard-access-for-non-admins
+        run: |
+          if svn ls "https://plugins.svn.wordpress.org/${SLUG}/tags/${VERSION}" --non-interactive >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::SVN tag ${VERSION} already exists on wordpress.org; skipping the 10up deploy step."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "SVN tag ${VERSION} not present; proceeding with deploy."
+          fi
+
       - name: WordPress Plugin Deploy
         id: deploy
+        if: steps.svn_tag_check.outputs.exists == 'false'
         uses: 10up/action-wordpress-plugin-deploy@stable
         with:
           generate-zip: true
@@ -94,6 +116,11 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SLUG: remove-dashboard-access-for-non-admins
+          # Pass VERSION explicitly. Without this, the 10up action
+          # falls back to $GITHUB_REF which on a push-to-main is
+          # `refs/heads/main`, producing the nonsense SVN path
+          # `tags/refs/heads/main` and a hard failure.
+          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Upload deploy artifact
         if: steps.deploy.outputs.zip-path != ''

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -59,9 +59,31 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
+    # `contents: write` is needed for the tag-push + GitHub-Release steps
+    # below. Test runs (which don't have a deploy job) don't ask for it.
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history so the tag-push step's `git tag` knows about
+          # existing tags and we don't accidentally re-create one.
+          fetch-depth: 0
+
+      - name: Read plugin version
+        id: version
+        run: |
+          VERSION=$(grep -E '^[[:space:]]*\*?[[:space:]]*Version:' remove-dashboard-access.php \
+            | head -1 \
+            | sed -E 's/.*Version:[[:space:]]*//; s/[[:space:]]*$//')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not parse Version: from remove-dashboard-access.php"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected plugin version: $VERSION"
 
       - name: WordPress Plugin Deploy
         id: deploy
@@ -79,3 +101,79 @@ jobs:
         with:
           name: ${{ github.event.repository.name }}-${{ github.sha }}
           path: ${{ steps.deploy.outputs.zip-path }}
+
+      # Mirror the WP.org SVN tag onto the GitHub repo so the two are
+      # always in lockstep. Convention here is bare semver (`1.3.0`),
+      # matching prior tags like `1.2`, `1.1.5`, etc. — no `v` prefix.
+      - name: Tag git repo with plugin version
+        if: success()
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if git rev-parse "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${VERSION} already exists locally; skipping."
+            exit 0
+          fi
+          if git ls-remote --tags --exit-code origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${VERSION} already exists on origin; skipping."
+            exit 0
+          fi
+
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "${VERSION}" -m "Release ${VERSION}"
+          git push origin "${VERSION}"
+
+      # Cut a GitHub Release with the changelog block for this version
+      # extracted from readme.txt + the deploy zip attached. Skips if a
+      # release already exists for the tag (idempotent across re-runs).
+      - name: Extract changelog notes
+        if: success()
+        id: notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          NOTES_FILE="${RUNNER_TEMP}/release-notes.md"
+          awk -v v="${VERSION}" '
+            BEGIN { f = 0 }
+            /^= / {
+              if (f) exit
+              if (index($0, "= " v " on") == 1) f = 1
+              next
+            }
+            f { print }
+          ' readme.txt > "${NOTES_FILE}"
+
+          if [ ! -s "${NOTES_FILE}" ]; then
+            echo "::warning::Could not extract changelog notes for ${VERSION}; release will use auto-generated notes."
+          fi
+          echo "notes-file=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          NOTES_FILE: ${{ steps.notes.outputs.notes-file }}
+          ZIP_PATH: ${{ steps.deploy.outputs.zip-path }}
+        run: |
+          if gh release view "${VERSION}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "GitHub Release for ${VERSION} already exists; skipping."
+            exit 0
+          fi
+
+          NOTES_FLAG=(--generate-notes)
+          if [ -s "${NOTES_FILE}" ]; then
+            NOTES_FLAG=(--notes-file "${NOTES_FILE}")
+          fi
+
+          ATTACH_ARGS=()
+          if [ -n "${ZIP_PATH}" ] && [ -f "${ZIP_PATH}" ]; then
+            ATTACH_ARGS=("${ZIP_PATH}")
+          fi
+
+          gh release create "${VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${VERSION}" \
+            "${NOTES_FLAG[@]}" \
+            "${ATTACH_ARGS[@]}"

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -16,10 +16,21 @@ on:
 # Plugin slug on WordPress.org: remove-dashboard-access-for-non-admins
 # The deploy is driven by `Stable tag:` in readme.txt; bump that to ship.
 
+# Minimum-privilege default. Jobs that need write access opt in explicitly
+# via their own `permissions:` block. Without this, GitHub's repo default
+# (often `write-all`) would silently grant the test job more scope than it
+# needs.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: PHPUnit (wp-env)
     runs-on: ubuntu-latest
+
+    # Test job reads code from the repo; nothing else.
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -58,6 +69,16 @@ jobs:
     # convention of "merge to main = ship."
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+
+    # Serialize concurrent pushes to main so two rapid merges don't race
+    # against the WP.org SVN at the same time (the second would fail with
+    # a noisy "tag already exists" mid-deploy). `cancel-in-progress: false`
+    # lets the second push WAIT for the first deploy to finish, then run
+    # its own deploy — which will short-circuit via the SVN-tag idempotency
+    # guard if the first push already published the same version.
+    concurrency:
+      group: deploy-wordpress-org
+      cancel-in-progress: false
 
     # `contents: write` is needed for the tag-push + GitHub-Release steps
     # below. Test runs (which don't have a deploy job) don't ask for it.
@@ -109,7 +130,12 @@ jobs:
       - name: WordPress Plugin Deploy
         id: deploy
         if: steps.svn_tag_check.outputs.exists == 'false'
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        # SHA-pinned to 2.3.0 (Apr 2025) — a floating `@stable` would let any
+        # commit pushed to that branch by 10up (or by an attacker via a
+        # compromised account) run with SVN credentials + `contents: write`
+        # in scope. Bump deliberately by replacing the SHA + bumping the
+        # comment when reviewing a new 10up release.
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2
         with:
           generate-zip: true
         env:
@@ -161,18 +187,31 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           NOTES_FILE="${RUNNER_TEMP}/release-notes.md"
+          # Match any wp.org-style version heading for our version, tolerating
+          # the common variants the readme might drift into:
+          #   = 1.3.0 =
+          #   = 1.3.0 on May 22, 2026 =
+          #   = v1.3.0 on May 22, 2026 =
+          # Section ends at the next `= ` heading at column 1.
+          # Anchored to start-of-line so a sentence containing "= 1.3.0" inside
+          # a bullet can't false-match.
           awk -v v="${VERSION}" '
-            BEGIN { f = 0 }
+            BEGIN {
+              # Pattern: optional `v`, the version, optional whitespace + extras,
+              # closing `=`. Matches `= 1.3.0 =`, `= 1.3.0 on … =`, etc.
+              vpat = "^= v?" v "([ \t][^=]*)?=[ \t]*$"
+              f = 0
+            }
             /^= / {
               if (f) exit
-              if (index($0, "= " v " on") == 1) f = 1
+              if ($0 ~ vpat) f = 1
               next
             }
             f { print }
           ' readme.txt > "${NOTES_FILE}"
 
           if [ ! -s "${NOTES_FILE}" ]; then
-            echo "::warning::Could not extract changelog notes for ${VERSION}; release will use auto-generated notes."
+            echo "::warning::Could not extract changelog notes for ${VERSION} from readme.txt; release will fall back to GitHub auto-generated commit notes."
           fi
           echo "notes-file=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
 
@@ -194,9 +233,16 @@ jobs:
             NOTES_FLAG=(--notes-file "${NOTES_FILE}")
           fi
 
+          # The deploy step is skipped when the SVN tag already exists
+          # (re-runs after an SVN-only release). In that case there is no
+          # local zip — surface a warning so the run output makes clear
+          # the release ships without an attached zip, rather than
+          # silently producing a thinner release than usual.
           ATTACH_ARGS=()
           if [ -n "${ZIP_PATH}" ] && [ -f "${ZIP_PATH}" ]; then
             ATTACH_ARGS=("${ZIP_PATH}")
+          else
+            echo "::warning::No deploy zip available (deploy step was skipped). Creating GitHub Release without an attached zip."
           fi
 
           gh release create "${VERSION}" \


### PR DESCRIPTION
## Summary

The 1.3.0 deploy on PR #44's merge failed with `svn: E155010: Path '…/tags/refs/heads' is not a directory`. The 10up action was reading `VERSION` from `\$GITHUB_REF`, which on a branch-push is `refs/heads/main` — producing nonsense SVN paths. This PR fixes that and adds the missing git-tag + GitHub-Release automation we discussed during PR #44 review.

Run that exposed the bug: https://github.com/trustedlogin/Remove-Dashboard-Access/actions/runs/26303856524

## What's in this PR

### Commit `02451dc` — the actual deploy fix

- Passes `VERSION` explicitly to the 10up action from the `Version:` header in `remove-dashboard-access.php`. Plugin header, readme `Stable tag:`, and SVN tag are now driven by one canonical source.
- Adds a pre-flight SVN-tag-exists check that short-circuits the deploy step (with a `::notice::` in the run log) if the WP.org SVN already has the version tagged. Makes re-runs idempotent.

### Commit `f8dea0a` — git tag + GitHub Release automation

(Was queued for PR #44 but got pushed to develop after the merge.) Adds three steps that run after the 10up deploy succeeds:

1. Push a `1.3.0` git tag to GitHub (bare semver, matching the existing tag convention: `1.2`, `1.1.5`, …). Skips if the tag exists locally or on origin.
2. Extract the `= 1.3.0 on … =` block from `readme.txt` via awk.
3. Create a GitHub Release with the changelog as the body + the deploy zip attached. Skips if the release already exists.

Adds `permissions: contents: write` at the deploy-job level so the tag-push + release-creation calls have the necessary scope (test job doesn't ask for it).

## After merge, the expected flow

```
push to main
  → test job runs PHPUnit suite
  → deploy job:
      → reads VERSION=1.3.0 from plugin header
      → checks SVN: 1.3.0 not present
      → 10up action: push trunk + create tags/1.3.0/ on plugins.svn.wordpress.org
      → git tag 1.3.0 pushed to origin
      → GitHub Release "1.3.0" created with readme changelog + zip attached
```

Re-running the workflow afterwards is now a no-op (all three steps' existence guards trip).

## Test plan

- [x] Workflow YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] Merge → CI runs → deploy succeeds → SVN tag `1.3.0` appears → git tag `1.3.0` appears → GitHub Release `1.3.0` appears
- [ ] Manual re-run of the workflow on the same commit logs "SVN tag 1.3.0 already exists; skipping the 10up deploy step." and exits clean

---

## Update: agent code review applied

Ran the feature-dev:code-reviewer agent over the workflow before requesting review. It flagged **P0** + **P1** items; both classes addressed in commit `0063364`:

| Severity | Finding | Fix in this PR |
|---|---|---|
| **P0** | `10up/action-wordpress-plugin-deploy@stable` is a mutable branch — anyone with push access to that branch (or a 10up account compromise) gets SVN credentials + `contents: write` on the next run | Pinned to SHA `54bd289` (= 2.3.0, Apr 2025). Bumped deliberately on review. |
| **P0** | Re-run scenarios where SVN already has the tag but GitHub Release doesn't would silently ship a release with no zip attached | Now emits `::warning::` to the run log so the operator sees the missing artifact |
| **P1** | No workflow-level `permissions:` block — both jobs inherit repo defaults (often `write-all`) | Added `permissions: contents: read` at workflow scope + on the test job; deploy job's existing `contents: write` is now the only escalation point |
| **P1** | Two rapid pushes to main could race the SVN deploy | Added `concurrency: group: deploy-wordpress-org` with `cancel-in-progress: false` so the second push waits, then short-circuits via the idempotency guard |
| **P1** | `awk` pattern only matched `= X.Y.Z on …` headings — a drift to `= 1.3.1 =` (the wp.org-legal short form) would silently produce empty release notes | Pattern now tolerates optional `v` prefix, optional date/extras, anchored start-and-end-of-line |

P2 (artifact-upload-skipped-on-re-run leaves no log trace) explicitly skipped — documented as a known observability gap rather than fixed at the cost of complexity.
