### PR TITLE
Fix wp.org asset sync path + move SVN creds plugin-local

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -51,3 +51,7 @@
 .vscode
 *.swp
 *.swo
+
+# Plugin-local secrets — must never leave the contributor's machine.
+/.env
+/.env.example

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Plugin-local credentials for manual SVN operations against the
+# wordpress.org repository at:
+#   https://plugins.svn.wordpress.org/remove-dashboard-access-for-non-admins/
+#
+# These are NOT used by CI — the GitHub Actions deploy workflow reads
+# repo-level secrets (`SVN_USERNAME` / `SVN_PASSWORD`) configured under
+# Settings → Secrets and variables → Actions. This file exists only so
+# a contributor can do local `svn co` / `svn commit` / `svn lock` /
+# asset-fixup work without re-deriving the credentials from scratch
+# each time.
+#
+# How to populate this file:
+#   1. Copy this file to `.env` in the same directory (already
+#      gitignored + distignored — it never leaves your machine).
+#   2. Go to:
+#        https://wordpress.org/support/users/<your-wporg-username>/edit/
+#      then scroll to "Application Passwords".
+#   3. Generate an application password scoped to this plugin
+#      (`remove-dashboard-access-for-non-admins`).
+#   4. Paste the username + the resulting `svn_…` token below.
+#
+# Gotcha learned the hard way: the username field is CASE-SENSITIVE
+# for app-password auth even though plain svn-auth is case-insensitive.
+# Use the exact lowercase form shown in `svn log` for this plugin
+# (`trustedlogin`), not the CamelCase form `TrustedLogin`.
+
+# Required — your wordpress.org committer username (lowercase).
+WPORG_SVN_USERNAME=
+
+# Required — `svn_`-prefixed application password (not your account password).
+WPORG_SVN_PASSWORD=

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -147,6 +147,16 @@ jobs:
           # `refs/heads/main`, producing the nonsense SVN path
           # `tags/refs/heads/main` and a hard failure.
           VERSION: ${{ steps.version.outputs.version }}
+          # The 10up action's default ASSETS_DIR is `.wordpress-org`
+          # and it rsyncs THAT directory's contents into SVN
+          # `/assets/`. Our PNGs live one level deeper at
+          # `.wordpress-org/assets/`, so without this override the
+          # 1.3.0 deploy uploaded everything to `/assets/assets/*.png`
+          # — wordpress.org's plugin page reads from `/assets/*.png`,
+          # leaving the listing without banner/icon/screenshots until
+          # we fixed it by hand (SVN r3544334). Pin the deeper path
+          # so the action looks where our PNGs actually are.
+          ASSETS_DIR: .wordpress-org/assets
 
       - name: Upload deploy artifact
         if: steps.deploy.outputs.zip-path != ''

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 .vscode/
 *.swp
 *.swo
+
+# Plugin-local credentials (WP.org SVN creds for manual deploys / asset
+# fixes). `.env.example` is the template — committed, no real values.
+/.env


### PR DESCRIPTION
## Summary

Two follow-ups after the 1.3.0 deploy on PR #45's merge:

1. The deploy pushed banner/icon/screenshots to `/assets/assets/*.png` on wp.org SVN instead of `/assets/*.png`, leaving the plugin listing without any artwork. Manually corrected at SVN [r3544334](https://plugins.trac.wordpress.org/changeset/3544334) (assets now in the right place; nothing here changes that). This PR teaches the workflow to do it correctly next time.

2. The wordpress.org SVN credentials I was using are per-plugin app passwords, not a global TrustedLogin credential — putting them in `~/.monokit/.env` is what caused yesterday's `403 Access forbidden` mid-deploy (I tried to use the same token against a different plugin's SVN scope). Moved them out of the global file and into a plugin-local `.env` pattern.

## Commits

### `99b5c3e` — set `ASSETS_DIR` on the 10up step

```yaml
- name: WordPress Plugin Deploy
  uses: 10up/action-wordpress-plugin-deploy@54bd289…
  env:
    …
    ASSETS_DIR: .wordpress-org/assets   # ← new
```

10up's default `ASSETS_DIR` is `.wordpress-org` and the action rsyncs that directory's CONTENTS into SVN `/assets/`. Our repo has the PNGs at `.wordpress-org/assets/*.png` (matching the layout SVN actually uses for downloads), so the default produced `/assets/assets/*.png`. Pinning the deeper path makes the action look where our PNGs actually live.

Cheaper than the alternative — moving every PNG up one level — which would have required touching `tests/e2e/screenshots/screenshots.spec.js`'s `ASSETS_DIR` constant, the `.distignore` exclusion path, and the SVN-mirror layout in `853d7ce`.

### `a4b25d6` — move SVN credentials to plugin-local `.env`

wordpress.org app passwords for SVN are scoped per-plugin (confirmed empirically: the `trustedlogin` user's token for `remove-dashboard-access-for-non-admins` returns 403 against `trustedlogin-connector` and vice versa). Storing them in `~/.monokit/.env` invited the cross-plugin-auth bug we hit yesterday.

  - `.env.example` (committed) — documents the variables (`WPORG_SVN_USERNAME`, `WPORG_SVN_PASSWORD`), where to get the app password, and the **case-sensitivity gotcha** we discovered: even though plain `svn` auth is case-insensitive, wordpress.org's app-password auth IS case-sensitive on the username. The committer's username must match the lowercase form shown in `svn log`, not the CamelCase display name.
  - `.env` (gitignored + distignored) — contributors copy from `.env.example`, paste their token, and `source ./.env` for any local SVN op (asset fixes, manual commits, lock probes).
  - `.gitignore` + `.distignore` exclude both `.env` and the real `.env.example` path so a future contributor's clone can't accidentally ship them.
  - **CI is unaffected** — `.github/workflows/test-and-deploy.yml` reads repo-level `SVN_USERNAME` / `SVN_PASSWORD` secrets, not any `.env` file.

## What's NOT in this PR

- No code changes to the plugin itself (1.3.0 is shipped as-is).
- No version bump.
- No new tests — `npm test` still passes at the same 114 tests / 188 assertions from before.
- The 1.3.0 SVN tag stays on wp.org. If we ever need to redeploy 1.3.0 (e.g., another asset mishap), bumping `Stable tag:` to `1.3.1` and merging will fire the workflow with the corrected `ASSETS_DIR` configuration.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test-and-deploy.yml'))"` — workflow YAML parses cleanly.
- [x] `git check-ignore -v .env` confirms it's gitignored.
- [x] `git check-ignore -v .env.example` confirms it's NOT ignored (committable template).
- [x] Local `source ./.env && svn ls --username "$WPORG_SVN_USERNAME" --password "$WPORG_SVN_PASSWORD" https://…/assets/` lists the seven PNGs (confirmed — credentials live where the new pattern says they should, and they still authenticate).
- [ ] Next deploy after a `Stable tag:` bump syncs assets to `/assets/*.png` without manual SVN cleanup.