### PR TITLE
Release 1.3.1 — add License headers per wp.org reviewer warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remove-dashboard-access",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "description": "Dev tooling for Remove Dashboard Access. Powered by @wordpress/scripts + @wordpress/env.",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,10 @@ Donate link: https://www.trustedlogin.com
 Tags: dashboard, access, administration, login, restrict
 Requires at least: 3.1.0
 Tested up to: 7.0
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 Requires PHP: 5.3
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Disable Dashboard access for users of a specific role or capability. Disallowed users are redirected to a chosen URL. Get set up in seconds.
 
@@ -155,6 +157,14 @@ Yes. The plugin does not collect any personal data, nor does it set any cookies.
 3. Optional login message.
 
 == Changelog ==
+
+= 1.3.1 on May 22, 2026 =
+
+This release adds the missing `License` headers that the wordpress.org plugin reviewer flagged during the 1.3.0 import. No functional change.
+
+#### 🐛 Fixed
+
+* Added the `License: GPLv2 or later` and `License URI: https://www.gnu.org/licenses/gpl-2.0.html` headers to `readme.txt` and normalized the plugin file's `License:` header to the same canonical form. The plugin has always been GPLv2-licensed; the headers were just missing from the locations wordpress.org's plugin directory parses.
 
 = 1.3.0 on May 22, 2026 =
 

--- a/remove-dashboard-access.php
+++ b/remove-dashboard-access.php
@@ -3,10 +3,11 @@
  * Plugin Name: Remove Dashboard Access
  * Plugin URI: https://www.trustedlogin.com/remove-dashboard-access/
  * Description: Removes Dashboard access for certain users based on capability.
- * Version: 1.3.0
+ * Version: 1.3.1
  * Author: TrustedLogin
  * Author URI: https://www.trustedlogin.com
- * License: GPLv2
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Requires PHP: 5.3
  * Text Domain: remove-dashboard-access-for-non-admins
  */


### PR DESCRIPTION
## Summary

Bumps to **1.3.1** to resolve the wordpress.org plugin reviewer warning that surfaced after the 1.3.0 import:

> The License field is missing. A GPLv2 or later compatible license should be specified.
> _(visible only to committers)_

The plugin has always been GPLv2 — the headers just weren't in the form wordpress.org's plugin directory parses.

This is a metadata-only release. No code path changes, no test changes.

## What's in this PR

### `c9ea50f` — release 1.3.1

- **`remove-dashboard-access.php`** — `License: GPLv2` → `License: GPLv2 or later`, added `License URI: https://www.gnu.org/licenses/gpl-2.0.html`. Version bumped to `1.3.1`.
- **`readme.txt`** — added the same `License:` + `License URI:` lines to the metadata block at the top (parsed separately from the PHP header). `Stable tag:` bumped to `1.3.1`. New 1.3.1 changelog entry above the 1.3.0 block.
- **`package.json`** — version field bumped to `1.3.1` for parity.

## Test plan

- [x] `npm test` — 114 PHPUnit tests / 188 assertions, all green (license-header change has no functional impact).
- [x] `php -l remove-dashboard-access.php` — no syntax errors.
- [x] `grep Version: + Stable tag: + "version":` — all three aligned at `1.3.1`.
- [x] Both `License:` headers now read `GPLv2 or later` (the wordpress.org-accepted canonical form).
- [ ] After merge: deploy workflow runs against the SHA-pinned 10up action with `ASSETS_DIR: .wordpress-org/assets` (the fix from PR #46) → SVN trunk + `tags/1.3.1/` published, banner/icon/screenshots sync to `/assets/*.png` correctly, the reviewer warning clears on the next 1.3.1 import.

## Side benefit

This release doubles as the "trunk commit that triggers wp.org's metadata re-scan" we needed anyway for the 1.3.0 assets that didn't get picked up. The manual `svn:eol-style` property commit I did earlier (SVN r3544350) was belt-and-suspenders; the 1.3.1 version bump is the canonical fix.